### PR TITLE
Message Event not Responding Fix

### DIFF
--- a/src/websocket/WebSocketManager.js
+++ b/src/websocket/WebSocketManager.js
@@ -59,7 +59,7 @@ class WebSocketManager extends EventEmitter {
                 break;
 
             case 'MESSAGE_CREATE':
-                if (this._state) return;
+                if (!this._state) return;
                 packet.d = new Message(this, packet.d);
                 if (!this.users.has(packet.d.author.id)) this.users.set(packet.d.user.id, new User(this.client, packet.d));
                 this.emit(Constants.Events.MESSAGE_CREATE, packet.d);


### PR DESCRIPTION
You added `if (this._state) return;` which prevents the message event from being emitted. `this._state` will only be null if the ready event isn't triggered yet. Once it is, `this._state` will return `ready` and in that case, it will return true.